### PR TITLE
build: code clean and fix compile error when -std=c++2a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,7 +215,7 @@ if (BUILD_TESTS OR BUILD_EXAMPLES)
     set (Boost_USE_MULTITHREADED TRUE)
     set (Boost_ADDITIONAL_VERSIONS "1.39.0" "1.40.0" "1.41.0" "1.42.0" "1.43.0" "1.44.0" "1.46.1") # todo: someone who knows better spesify these!
 
-    find_package (Boost 1.39.0 COMPONENTS "${WEBSOCKETPP_BOOST_LIBS}")
+    find_package (Boost 1.39.0 COMPONENTS ${WEBSOCKETPP_BOOST_LIBS})
 
     if (Boost_FOUND)
         # Boost is a project wide global dependency.

--- a/websocketpp/endpoint.hpp
+++ b/websocketpp/endpoint.hpp
@@ -109,7 +109,7 @@ public:
 
 
     /// Destructor
-    ~endpoint<connection,config>() {}
+    ~endpoint() {}
 
     #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
         // no copy constructor because endpoints are not copyable

--- a/websocketpp/logger/basic.hpp
+++ b/websocketpp/logger/basic.hpp
@@ -58,33 +58,32 @@ namespace log {
 template <typename concurrency, typename names>
 class basic {
 public:
-    basic<concurrency,names>(channel_type_hint::value h =
-        channel_type_hint::access)
+    basic(channel_type_hint::value h = channel_type_hint::access)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
 
-    basic<concurrency,names>(std::ostream * out)
+    basic(std::ostream * out)
       : m_static_channels(0xffffffff)
       , m_dynamic_channels(0)
       , m_out(out) {}
 
-    basic<concurrency,names>(level c, channel_type_hint::value h =
+    basic(level c, channel_type_hint::value h =
         channel_type_hint::access)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(h == channel_type_hint::error ? &std::cerr : &std::cout) {}
 
-    basic<concurrency,names>(level c, std::ostream * out)
+    basic(level c, std::ostream * out)
       : m_static_channels(c)
       , m_dynamic_channels(0)
       , m_out(out) {}
 
     /// Destructor
-    ~basic<concurrency,names>() {}
+    ~basic() {}
 
     /// Copy constructor
-    basic<concurrency,names>(basic<concurrency,names> const & other)
+    basic(basic<concurrency,names> const & other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)
@@ -92,12 +91,12 @@ public:
     
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no copy assignment operator because of const member variables
-    basic<concurrency,names> & operator=(basic<concurrency,names> const &) = delete;
+    basic & operator=(basic<concurrency,names> const &) = delete;
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
     /// Move constructor
-    basic<concurrency,names>(basic<concurrency,names> && other)
+    basic(basic<concurrency,names> && other)
      : m_static_channels(other.m_static_channels)
      , m_dynamic_channels(other.m_dynamic_channels)
      , m_out(other.m_out)
@@ -105,7 +104,7 @@ public:
 
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no move assignment operator because of const member variables
-    basic<concurrency,names> & operator=(basic<concurrency,names> &&) = delete;
+    basic & operator=(basic<concurrency,names> &&) = delete;
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #endif // _WEBSOCKETPP_MOVE_SEMANTICS_

--- a/websocketpp/logger/syslog.hpp
+++ b/websocketpp/logger/syslog.hpp
@@ -51,7 +51,7 @@ public:
     /**
      * @param hint A channel type specific hint for how to construct the logger
      */
-    syslog<concurrency,names>(channel_type_hint::value hint =
+    syslog(channel_type_hint::value hint =
         channel_type_hint::access)
       : basic<concurrency,names>(hint), m_channel_type_hint(hint) {}
 
@@ -60,7 +60,7 @@ public:
      * @param channels A set of channels to statically enable
      * @param hint A channel type specific hint for how to construct the logger
      */
-    syslog<concurrency,names>(level channels, channel_type_hint::value hint =
+    syslog(level channels, channel_type_hint::value hint =
         channel_type_hint::access)
       : basic<concurrency,names>(channels, hint), m_channel_type_hint(hint) {}
 

--- a/websocketpp/roles/server_endpoint.hpp
+++ b/websocketpp/roles/server_endpoint.hpp
@@ -72,23 +72,23 @@ public:
     }
 
     /// Destructor
-    ~server<config>() {}
+    ~server() {}
 
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no copy constructor because endpoints are not copyable
-    server<config>(server<config> &) = delete;
+    server(server<config> &) = delete;
 
     // no copy assignment operator because endpoints are not copyable
-    server<config> & operator=(server<config> const &) = delete;
+    server & operator=(server<config> const &) = delete;
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #ifdef _WEBSOCKETPP_MOVE_SEMANTICS_
     /// Move constructor
-    server<config>(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
+    server(server<config> && o) : endpoint<connection<config>,config>(std::move(o)) {}
 
 #ifdef _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
     // no move assignment operator because of const member variables
-    server<config> & operator=(server<config> &&) = delete;
+    server & operator=(server<config> &&) = delete;
 #endif // _WEBSOCKETPP_DEFAULT_DELETE_FUNCTIONS_
 
 #endif // _WEBSOCKETPP_MOVE_SEMANTICS_


### PR DESCRIPTION
Removed redundant template lists in constructor and destructor

More: https://stackoverflow.com/a/63514123/10566048